### PR TITLE
chore(example): bump version to 0.2.0

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "^2.31.0",
-        "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.1.0",
+        "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.2.0",
         "constructs": "^10.1.43",
         "source-map-support": "^0.5.21"
       },
@@ -1630,8 +1630,8 @@
       ]
     },
     "node_modules/cdk-rest-api-with-spec": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/codemonger-io/cdk-rest-api-with-spec.git#db65b5b6c2390c27931a0ca9e3d9c7445fca3126",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/codemonger-io/cdk-rest-api-with-spec.git#7d610b2dcc7369a782c4535b922c75bae5a2d418",
       "license": "MIT",
       "dependencies": {
         "openapi3-ts": "^2.0.2"
@@ -5749,8 +5749,8 @@
       "dev": true
     },
     "cdk-rest-api-with-spec": {
-      "version": "git+ssh://git@github.com/codemonger-io/cdk-rest-api-with-spec.git#db65b5b6c2390c27931a0ca9e3d9c7445fca3126",
-      "from": "cdk-rest-api-with-spec@github:codemonger-io/cdk-rest-api-with-spec#v0.1.0",
+      "version": "git+ssh://git@github.com/codemonger-io/cdk-rest-api-with-spec.git#7d610b2dcc7369a782c4535b922c75bae5a2d418",
+      "from": "cdk-rest-api-with-spec@https://github.com/codemonger-io/cdk-rest-api-with-spec.git#v0.2.0",
       "requires": {
         "openapi3-ts": "^2.0.2"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.31.0",
-    "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.1.0",
+    "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.2.0",
     "constructs": "^10.1.43",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
- Installs `cdk-rest-api-with-spec#v0.2.0`.

issue
- codemonger-io/cdk-rest-api-with-spec#6