### PR TITLE
Update example dependency --> 0.2.1

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "^2.31.0",
-        "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.2.0",
+        "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.2.1",
         "constructs": "^10.1.43",
         "source-map-support": "^0.5.21"
       },
@@ -5750,7 +5750,7 @@
     },
     "cdk-rest-api-with-spec": {
       "version": "git+ssh://git@github.com/codemonger-io/cdk-rest-api-with-spec.git#7d610b2dcc7369a782c4535b922c75bae5a2d418",
-      "from": "cdk-rest-api-with-spec@https://github.com/codemonger-io/cdk-rest-api-with-spec.git#v0.2.0",
+      "from": "cdk-rest-api-with-spec@github:codemonger-io/cdk-rest-api-with-spec#v0.2.1",
       "requires": {
         "openapi3-ts": "^2.0.2"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.31.0",
-    "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.2.0",
+    "cdk-rest-api-with-spec": "github:codemonger-io/cdk-rest-api-with-spec#v0.2.1",
     "constructs": "^10.1.43",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
Bumps the version of `cdk-rest-api-with-spec` in the example to 0.2.1.