### PR TITLE
Fix: Pass down parameters (#13)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@
 このレポジトリを依存関係(`dependencies`)に追加してください。
 
 ```sh
-npm install https://github.com/codemonger-io/cdk-rest-api-with-spec.git#v0.2.2
+npm install https://github.com/codemonger-io/cdk-rest-api-with-spec.git#v0.2.3
 ```
 
 このライブラリはCDK v2プロジェクトで使用することを想定しており、以下のモジュールは`dependencies`ではなく`peerDependencies`に含んでいます。
@@ -297,7 +297,7 @@ const authorizer = augmentAuthorizer(
     {
       handler: new nodejs.NodejsFunction(this, 'authorizer', {
         description: 'Example authorizer',
-        runtime: lambda.Runtime.NODEJS_16_X,
+        runtime: lambda.Runtime.NODEJS_18_X,
       }),
     },
   ),

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is implemented for the CDK **version 2** (CDK v2) and does not work
 Please add this repository to your dependencies.
 
 ```sh
-npm install https://github.com/codemonger-io/cdk-rest-api-with-spec.git#v0.2.2
+npm install https://github.com/codemonger-io/cdk-rest-api-with-spec.git#v0.2.3
 ```
 
 This library is supposed to be used in a CDK v2 project, so it does not include the following modules in the `dependencies` but does in the `peerDependencies`.
@@ -297,7 +297,7 @@ const authorizer = augmentAuthorizer(
     {
       handler: new nodejs.NodejsFunction(this, 'authorizer', {
         description: 'Example authorizer',
-        runtime: lambda.Runtime.NODEJS_16_X,
+        runtime: lambda.Runtime.NODEJS_18_X,
       }),
     },
   ),

--- a/api-docs/markdown/cdk-rest-api-with-spec.augmentauthorizer.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.augmentauthorizer.md
@@ -4,12 +4,12 @@
 
 ## augmentAuthorizer() function
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Makes a given [aws\_apigateway.IAuthorizer](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IAuthorizer.html) an [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md) by augmenting it with a specified security scheme object.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare function augmentAuthorizer(authorizer: apigateway.IAuthorizer, securitySchemeObject: SecuritySchemeObject): IAuthorizerWithSpec;
@@ -22,7 +22,7 @@ export declare function augmentAuthorizer(authorizer: apigateway.IAuthorizer, se
 |  authorizer | apigateway.IAuthorizer | Authorizer to be augmented. |
 |  securitySchemeObject | SecuritySchemeObject | Security scheme object to add to <code>authorizer</code>. |
 
-<b>Returns:</b>
+**Returns:**
 
 [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md)
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.iauthorizerwithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.iauthorizerwithspec.md
@@ -4,21 +4,21 @@
 
 ## IAuthorizerWithSpec interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Authorizer augmented with the features to describe the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IAuthorizerWithSpec extends apigateway.IAuthorizer 
 ```
-<b>Extends:</b> apigateway.IAuthorizer
+**Extends:** apigateway.IAuthorizer
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [securitySchemeObject?](./cdk-rest-api-with-spec.iauthorizerwithspec.securityschemeobject.md) |  | SecuritySchemeObject | <b><i>(BETA)</i></b> <i>(Optional)</i> Security scheme object representing this authorizer. |
+|  [securitySchemeObject?](./cdk-rest-api-with-spec.iauthorizerwithspec.securityschemeobject.md) |  | SecuritySchemeObject | **_(BETA)_** _(Optional)_ Security scheme object representing this authorizer. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.iauthorizerwithspec.securityschemeobject.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.iauthorizerwithspec.securityschemeobject.md
@@ -4,12 +4,12 @@
 
 ## IAuthorizerWithSpec.securitySchemeObject property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Security scheme object representing this authorizer.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 securitySchemeObject?: SecuritySchemeObject;

--- a/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.addmethod.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.addmethod.md
@@ -4,12 +4,12 @@
 
 ## IResourceWithSpec.addMethod() method
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Adds a method with the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 addMethod(httpMethod: string, target?: apigateway.Integration, options?: MethodOptionsWithSpec): apigateway.Method;
@@ -20,10 +20,10 @@ addMethod(httpMethod: string, target?: apigateway.Integration, options?: MethodO
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  httpMethod | string |  |
-|  target | apigateway.Integration | <i>(Optional)</i> |
-|  options | [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | <i>(Optional)</i> |
+|  target | apigateway.Integration | _(Optional)_ |
+|  options | [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | _(Optional)_ |
 
-<b>Returns:</b>
+**Returns:**
 
 apigateway.Method
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.addresource.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.addresource.md
@@ -4,12 +4,12 @@
 
 ## IResourceWithSpec.addResource() method
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Adds a new child resource with the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 addResource(pathPart: string, options?: ResourceOptionsWithSpec): IResourceWithSpec;
@@ -20,9 +20,9 @@ addResource(pathPart: string, options?: ResourceOptionsWithSpec): IResourceWithS
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  pathPart | string |  |
-|  options | [ResourceOptionsWithSpec](./cdk-rest-api-with-spec.resourceoptionswithspec.md) | <i>(Optional)</i> |
+|  options | [ResourceOptionsWithSpec](./cdk-rest-api-with-spec.resourceoptionswithspec.md) | _(Optional)_ |
 
-<b>Returns:</b>
+**Returns:**
 
 [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md)
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.defaultmethodoptions.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.defaultmethodoptions.md
@@ -4,12 +4,12 @@
 
 ## IResourceWithSpec.defaultMethodOptions property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Default method options with the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 defaultMethodOptions?: MethodOptionsWithSpec;

--- a/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.md
@@ -4,17 +4,17 @@
 
 ## IResourceWithSpec interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 [aws\_apigateway.IResource](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IResource.html) augmented with the features to build the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IResourceWithSpec extends apigateway.Resource 
 ```
-<b>Extends:</b> apigateway.Resource
+**Extends:** apigateway.Resource
 
 ## Remarks
 
@@ -24,13 +24,13 @@ Although this interface actually inherits [aws\_apigateway.Resource](https://doc
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [defaultMethodOptions?](./cdk-rest-api-with-spec.iresourcewithspec.defaultmethodoptions.md) |  | [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | <b><i>(BETA)</i></b> <i>(Optional)</i> Default method options with the OpenAPI definition. |
-|  [parentResource?](./cdk-rest-api-with-spec.iresourcewithspec.parentresource.md) |  | [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | <b><i>(BETA)</i></b> <i>(Optional)</i> Parent resource. |
+|  [defaultMethodOptions?](./cdk-rest-api-with-spec.iresourcewithspec.defaultmethodoptions.md) |  | [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | **_(BETA)_** _(Optional)_ Default method options with the OpenAPI definition. |
+|  [parentResource?](./cdk-rest-api-with-spec.iresourcewithspec.parentresource.md) |  | [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | **_(BETA)_** _(Optional)_ Parent resource. |
 
 ## Methods
 
 |  Method | Description |
 |  --- | --- |
-|  [addMethod(httpMethod, target, options)](./cdk-rest-api-with-spec.iresourcewithspec.addmethod.md) | <b><i>(BETA)</i></b> Adds a method with the OpenAPI definition. |
-|  [addResource(pathPart, options)](./cdk-rest-api-with-spec.iresourcewithspec.addresource.md) | <b><i>(BETA)</i></b> Adds a new child resource with the OpenAPI definition. |
+|  [addMethod(httpMethod, target, options)](./cdk-rest-api-with-spec.iresourcewithspec.addmethod.md) | **_(BETA)_** Adds a method with the OpenAPI definition. |
+|  [addResource(pathPart, options)](./cdk-rest-api-with-spec.iresourcewithspec.addresource.md) | **_(BETA)_** Adds a new child resource with the OpenAPI definition. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.parentresource.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.iresourcewithspec.parentresource.md
@@ -4,12 +4,12 @@
 
 ## IResourceWithSpec.parentResource property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Parent resource.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 parentResource?: IResourceWithSpec;

--- a/api-docs/markdown/cdk-rest-api-with-spec.irestapiwithspec.addmodel.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.irestapiwithspec.addmodel.md
@@ -4,12 +4,12 @@
 
 ## IRestApiWithSpec.addModel() method
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Adds a new model.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 addModel(id: string, props: ModelOptionsWithSpec): apigateway.Model;
@@ -22,7 +22,7 @@ addModel(id: string, props: ModelOptionsWithSpec): apigateway.Model;
 |  id | string |  |
 |  props | [ModelOptionsWithSpec](./cdk-rest-api-with-spec.modeloptionswithspec.md) |  |
 
-<b>Returns:</b>
+**Returns:**
 
 apigateway.Model
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.irestapiwithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.irestapiwithspec.md
@@ -4,27 +4,27 @@
 
 ## IRestApiWithSpec interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 [aws\_apigateway.RestApi](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApi.html) augmented with the features to build the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IRestApiWithSpec extends apigateway.IRestApi 
 ```
-<b>Extends:</b> apigateway.IRestApi
+**Extends:** apigateway.IRestApi
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [root](./cdk-rest-api-with-spec.irestapiwithspec.root.md) | <code>readonly</code> | [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | <b><i>(BETA)</i></b> Root resource ('/') with the features to build the OpenAPI definition. |
+|  [root](./cdk-rest-api-with-spec.irestapiwithspec.root.md) | <code>readonly</code> | [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | **_(BETA)_** Root resource ('/') with the features to build the OpenAPI definition. |
 
 ## Methods
 
 |  Method | Description |
 |  --- | --- |
-|  [addModel(id, props)](./cdk-rest-api-with-spec.irestapiwithspec.addmodel.md) | <b><i>(BETA)</i></b> Adds a new model. |
+|  [addModel(id, props)](./cdk-rest-api-with-spec.irestapiwithspec.addmodel.md) | **_(BETA)_** Adds a new model. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.irestapiwithspec.root.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.irestapiwithspec.root.md
@@ -4,12 +4,12 @@
 
 ## IRestApiWithSpec.root property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Root resource ('/') with the features to build the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly root: IResourceWithSpec;

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.additionalitems.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.additionalitems.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.additionalItems property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [additionalItems](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#additionalitems)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 additionalItems?: JsonSchemaEx[];

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.additionalproperties.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.additionalproperties.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.additionalProperties property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [additionalProperties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#additionalproperties)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 additionalProperties?: boolean | JsonSchemaEx;

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.allof.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.allof.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.allOf property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [allOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#allof)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 allOf?: JsonSchemaEx[];

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.anyof.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.anyof.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.anyOf property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [anyOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#anyof)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 anyOf?: JsonSchemaEx[];

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.contains.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.contains.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.contains property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [contains](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#contains)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 contains?: JsonSchemaEx | JsonSchemaEx[];

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.definitions.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.definitions.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.definitions property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [definitions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#definitions)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 definitions?: {

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.dependencies.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.dependencies.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.dependencies property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [dependencies](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#dependencies)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 dependencies?: {

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.example.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.example.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.example property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Example value.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 example?: any;

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.items.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.items.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.items property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [items](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#items)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 items?: JsonSchemaEx | JsonSchemaEx[];

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.md
@@ -4,17 +4,17 @@
 
 ## JsonSchemaEx interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extended [aws\_apigateway.JsonSchema](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface JsonSchemaEx extends apigateway.JsonSchema 
 ```
-<b>Extends:</b> apigateway.JsonSchema
+**Extends:** apigateway.JsonSchema
 
 ## Remarks
 
@@ -29,19 +29,19 @@ Introduces the following new properties,
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [additionalItems?](./cdk-rest-api-with-spec.jsonschemaex.additionalitems.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [additionalItems](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#additionalitems)<!-- -->. |
-|  [additionalProperties?](./cdk-rest-api-with-spec.jsonschemaex.additionalproperties.md) |  | boolean \| [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [additionalProperties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#additionalproperties)<!-- -->. |
-|  [allOf?](./cdk-rest-api-with-spec.jsonschemaex.allof.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [allOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#allof)<!-- -->. |
-|  [anyOf?](./cdk-rest-api-with-spec.jsonschemaex.anyof.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [anyOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#anyof)<!-- -->. |
-|  [contains?](./cdk-rest-api-with-spec.jsonschemaex.contains.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) \| [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [contains](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#contains)<!-- -->. |
-|  [definitions?](./cdk-rest-api-with-spec.jsonschemaex.definitions.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->; } | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [definitions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#definitions)<!-- -->. |
-|  [dependencies?](./cdk-rest-api-with-spec.jsonschemaex.dependencies.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) \| string\[\]; } | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [dependencies](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#dependencies)<!-- -->. |
-|  [example?](./cdk-rest-api-with-spec.jsonschemaex.example.md) |  | any | <b><i>(BETA)</i></b> <i>(Optional)</i> Example value. |
-|  [items?](./cdk-rest-api-with-spec.jsonschemaex.items.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) \| [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [items](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#items)<!-- -->. |
-|  [modelRef?](./cdk-rest-api-with-spec.jsonschemaex.modelref.md) |  | apigateway.IModel | <b><i>(BETA)</i></b> <i>(Optional)</i> Reference to another [aws\_apigateway.IModel](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IModel.html)<!-- -->. |
-|  [not?](./cdk-rest-api-with-spec.jsonschemaex.not.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [not](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#not)<!-- -->. |
-|  [oneOf?](./cdk-rest-api-with-spec.jsonschemaex.oneof.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [oneOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#oneof)<!-- -->. |
-|  [patternProperties?](./cdk-rest-api-with-spec.jsonschemaex.patternproperties.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->; } | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [patternProperties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#patternproperties)<!-- -->. |
-|  [properties?](./cdk-rest-api-with-spec.jsonschemaex.properties.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->; } | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [properties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#properties-1)<!-- -->. |
-|  [propertyNames?](./cdk-rest-api-with-spec.jsonschemaex.propertynames.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | <b><i>(BETA)</i></b> <i>(Optional)</i> Extension of [propertyNames](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#propertynames)<!-- -->. |
+|  [additionalItems?](./cdk-rest-api-with-spec.jsonschemaex.additionalitems.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | **_(BETA)_** _(Optional)_ Extension of [additionalItems](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#additionalitems)<!-- -->. |
+|  [additionalProperties?](./cdk-rest-api-with-spec.jsonschemaex.additionalproperties.md) |  | boolean \| [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | **_(BETA)_** _(Optional)_ Extension of [additionalProperties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#additionalproperties)<!-- -->. |
+|  [allOf?](./cdk-rest-api-with-spec.jsonschemaex.allof.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | **_(BETA)_** _(Optional)_ Extension of [allOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#allof)<!-- -->. |
+|  [anyOf?](./cdk-rest-api-with-spec.jsonschemaex.anyof.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | **_(BETA)_** _(Optional)_ Extension of [anyOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#anyof)<!-- -->. |
+|  [contains?](./cdk-rest-api-with-spec.jsonschemaex.contains.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) \| [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | **_(BETA)_** _(Optional)_ Extension of [contains](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#contains)<!-- -->. |
+|  [definitions?](./cdk-rest-api-with-spec.jsonschemaex.definitions.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->; } | **_(BETA)_** _(Optional)_ Extension of [definitions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#definitions)<!-- -->. |
+|  [dependencies?](./cdk-rest-api-with-spec.jsonschemaex.dependencies.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) \| string\[\]; } | **_(BETA)_** _(Optional)_ Extension of [dependencies](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#dependencies)<!-- -->. |
+|  [example?](./cdk-rest-api-with-spec.jsonschemaex.example.md) |  | any | **_(BETA)_** _(Optional)_ Example value. |
+|  [items?](./cdk-rest-api-with-spec.jsonschemaex.items.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) \| [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | **_(BETA)_** _(Optional)_ Extension of [items](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#items)<!-- -->. |
+|  [modelRef?](./cdk-rest-api-with-spec.jsonschemaex.modelref.md) |  | apigateway.IModel | **_(BETA)_** _(Optional)_ Reference to another [aws\_apigateway.IModel](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IModel.html)<!-- -->. |
+|  [not?](./cdk-rest-api-with-spec.jsonschemaex.not.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | **_(BETA)_** _(Optional)_ Extension of [not](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#not)<!-- -->. |
+|  [oneOf?](./cdk-rest-api-with-spec.jsonschemaex.oneof.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->\[\] | **_(BETA)_** _(Optional)_ Extension of [oneOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#oneof)<!-- -->. |
+|  [patternProperties?](./cdk-rest-api-with-spec.jsonschemaex.patternproperties.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->; } | **_(BETA)_** _(Optional)_ Extension of [patternProperties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#patternproperties)<!-- -->. |
+|  [properties?](./cdk-rest-api-with-spec.jsonschemaex.properties.md) |  | { \[k: string\]: [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md)<!-- -->; } | **_(BETA)_** _(Optional)_ Extension of [properties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#properties-1)<!-- -->. |
+|  [propertyNames?](./cdk-rest-api-with-spec.jsonschemaex.propertynames.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | **_(BETA)_** _(Optional)_ Extension of [propertyNames](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#propertynames)<!-- -->. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.modelref.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.modelref.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.modelRef property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Reference to another [aws\_apigateway.IModel](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IModel.html)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 modelRef?: apigateway.IModel;

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.not.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.not.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.not property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [not](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#not)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 not?: JsonSchemaEx;

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.oneof.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.oneof.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.oneOf property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [oneOf](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#oneof)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 oneOf?: JsonSchemaEx[];

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.patternproperties.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.patternproperties.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.patternProperties property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [patternProperties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#patternproperties)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 patternProperties?: {

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.properties.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.properties.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.properties property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [properties](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#properties-1)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 properties?: {

--- a/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.propertynames.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.jsonschemaex.propertynames.md
@@ -4,12 +4,12 @@
 
 ## JsonSchemaEx.propertyNames property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extension of [propertyNames](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html#propertynames)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 propertyNames?: JsonSchemaEx;

--- a/api-docs/markdown/cdk-rest-api-with-spec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.md
@@ -10,26 +10,26 @@ Describe the Amazon API Gateway and OpenAPI definition at once with CDK.
 
 |  Class | Description |
 |  --- | --- |
-|  [ParameterKey](./cdk-rest-api-with-spec.parameterkey.md) | <b><i>(BETA)</i></b> Parsed request or response parameter key. |
-|  [RestApiWithSpec](./cdk-rest-api-with-spec.restapiwithspec.md) | <b><i>(BETA)</i></b> CDK construct that provisions an API Gateway REST API endpoint and also synthesizes the OpenAPI definition for it. |
+|  [ParameterKey](./cdk-rest-api-with-spec.parameterkey.md) | **_(BETA)_** Parsed request or response parameter key. |
+|  [RestApiWithSpec](./cdk-rest-api-with-spec.restapiwithspec.md) | **_(BETA)_** CDK construct that provisions an API Gateway REST API endpoint and also synthesizes the OpenAPI definition for it. |
 
 ## Functions
 
 |  Function | Description |
 |  --- | --- |
-|  [augmentAuthorizer(authorizer, securitySchemeObject)](./cdk-rest-api-with-spec.augmentauthorizer.md) | <b><i>(BETA)</i></b> Makes a given [aws\_apigateway.IAuthorizer](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IAuthorizer.html) an [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md) by augmenting it with a specified security scheme object. |
+|  [augmentAuthorizer(authorizer, securitySchemeObject)](./cdk-rest-api-with-spec.augmentauthorizer.md) | **_(BETA)_** Makes a given [aws\_apigateway.IAuthorizer](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IAuthorizer.html) an [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md) by augmenting it with a specified security scheme object. |
 
 ## Interfaces
 
 |  Interface | Description |
 |  --- | --- |
-|  [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md) | <b><i>(BETA)</i></b> Authorizer augmented with the features to describe the OpenAPI definition. |
-|  [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | <b><i>(BETA)</i></b> [aws\_apigateway.IResource](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IResource.html) augmented with the features to build the OpenAPI definition. |
-|  [IRestApiWithSpec](./cdk-rest-api-with-spec.irestapiwithspec.md) | <b><i>(BETA)</i></b> [aws\_apigateway.RestApi](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApi.html) augmented with the features to build the OpenAPI definition. |
-|  [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | <b><i>(BETA)</i></b> Extended [aws\_apigateway.JsonSchema](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html)<!-- -->. |
-|  [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | <b><i>(BETA)</i></b> [aws\_apigateway.MethodOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodOptions.html) augmented with the properties necessary to build the OpenAPI definition. |
-|  [MethodResponseWithSpec](./cdk-rest-api-with-spec.methodresponsewithspec.md) | <b><i>(BETA)</i></b> [aws\_apigateway.MethodResponse](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodResponse.html) augmented with properties necessary for the OpenAPI definition. |
-|  [ModelOptionsWithSpec](./cdk-rest-api-with-spec.modeloptionswithspec.md) | <b><i>(BETA)</i></b> [aws\_apigateway.ModelOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ModelOptions.html) augmented with the properties necessary to build the OpenAPI definition. |
-|  [ResourceOptionsWithSpec](./cdk-rest-api-with-spec.resourceoptionswithspec.md) | <b><i>(BETA)</i></b> [aws\_apigateway.ResourceOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ResourceOptions.html) augmented with the properties necessary to build the OpenAPI definition. |
-|  [RestApiWithSpecProps](./cdk-rest-api-with-spec.restapiwithspecprops.md) | <b><i>(BETA)</i></b> Properties for [RestApiWithSpec](./cdk-rest-api-with-spec.restapiwithspec.md)<!-- -->. |
+|  [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md) | **_(BETA)_** Authorizer augmented with the features to describe the OpenAPI definition. |
+|  [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | **_(BETA)_** [aws\_apigateway.IResource](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IResource.html) augmented with the features to build the OpenAPI definition. |
+|  [IRestApiWithSpec](./cdk-rest-api-with-spec.irestapiwithspec.md) | **_(BETA)_** [aws\_apigateway.RestApi](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApi.html) augmented with the features to build the OpenAPI definition. |
+|  [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | **_(BETA)_** Extended [aws\_apigateway.JsonSchema](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.JsonSchema.html)<!-- -->. |
+|  [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | **_(BETA)_** [aws\_apigateway.MethodOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodOptions.html) augmented with the properties necessary to build the OpenAPI definition. |
+|  [MethodResponseWithSpec](./cdk-rest-api-with-spec.methodresponsewithspec.md) | **_(BETA)_** [aws\_apigateway.MethodResponse](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodResponse.html) augmented with properties necessary for the OpenAPI definition. |
+|  [ModelOptionsWithSpec](./cdk-rest-api-with-spec.modeloptionswithspec.md) | **_(BETA)_** [aws\_apigateway.ModelOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ModelOptions.html) augmented with the properties necessary to build the OpenAPI definition. |
+|  [ResourceOptionsWithSpec](./cdk-rest-api-with-spec.resourceoptionswithspec.md) | **_(BETA)_** [aws\_apigateway.ResourceOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ResourceOptions.html) augmented with the properties necessary to build the OpenAPI definition. |
+|  [RestApiWithSpecProps](./cdk-rest-api-with-spec.restapiwithspecprops.md) | **_(BETA)_** Properties for [RestApiWithSpec](./cdk-rest-api-with-spec.restapiwithspec.md)<!-- -->. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.authorizer.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.authorizer.md
@@ -4,12 +4,12 @@
 
 ## MethodOptionsWithSpec.authorizer property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Authorizer augmented with the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 authorizer?: IAuthorizerWithSpec;

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.description.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.description.md
@@ -4,12 +4,12 @@
 
 ## MethodOptionsWithSpec.description property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Description of the method.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 description?: string;

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.md
@@ -4,17 +4,17 @@
 
 ## MethodOptionsWithSpec interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 [aws\_apigateway.MethodOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodOptions.html) augmented with the properties necessary to build the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface MethodOptionsWithSpec extends apigateway.MethodOptions 
 ```
-<b>Extends:</b> apigateway.MethodOptions
+**Extends:** apigateway.MethodOptions
 
 ## Remarks
 
@@ -24,9 +24,9 @@ export interface MethodOptionsWithSpec extends apigateway.MethodOptions
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [authorizer?](./cdk-rest-api-with-spec.methodoptionswithspec.authorizer.md) |  | [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md) | <b><i>(BETA)</i></b> <i>(Optional)</i> Authorizer augmented with the OpenAPI definition. |
-|  [description?](./cdk-rest-api-with-spec.methodoptionswithspec.description.md) |  | string | <b><i>(BETA)</i></b> <i>(Optional)</i> Description of the method. |
-|  [methodResponses?](./cdk-rest-api-with-spec.methodoptionswithspec.methodresponses.md) |  | [MethodResponseWithSpec](./cdk-rest-api-with-spec.methodresponsewithspec.md)<!-- -->\[\] | <b><i>(BETA)</i></b> <i>(Optional)</i> Method responses augmented with properties necessary for the OpenAPI definition. |
-|  [requestParameterSchemas?](./cdk-rest-api-with-spec.methodoptionswithspec.requestparameterschemas.md) |  | { \[key: string\]: BaseParameterObject; } | <b><i>(BETA)</i></b> <i>(Optional)</i> Request parameters which maps parameter objects for the OpenAPI definition instead of boolean values. |
-|  [summary?](./cdk-rest-api-with-spec.methodoptionswithspec.summary.md) |  | string | <b><i>(BETA)</i></b> <i>(Optional)</i> Summary of the method. |
+|  [authorizer?](./cdk-rest-api-with-spec.methodoptionswithspec.authorizer.md) |  | [IAuthorizerWithSpec](./cdk-rest-api-with-spec.iauthorizerwithspec.md) | **_(BETA)_** _(Optional)_ Authorizer augmented with the OpenAPI definition. |
+|  [description?](./cdk-rest-api-with-spec.methodoptionswithspec.description.md) |  | string | **_(BETA)_** _(Optional)_ Description of the method. |
+|  [methodResponses?](./cdk-rest-api-with-spec.methodoptionswithspec.methodresponses.md) |  | [MethodResponseWithSpec](./cdk-rest-api-with-spec.methodresponsewithspec.md)<!-- -->\[\] | **_(BETA)_** _(Optional)_ Method responses augmented with properties necessary for the OpenAPI definition. |
+|  [requestParameterSchemas?](./cdk-rest-api-with-spec.methodoptionswithspec.requestparameterschemas.md) |  | { \[key: string\]: BaseParameterObject; } | **_(BETA)_** _(Optional)_ Request parameters which maps parameter objects for the OpenAPI definition instead of boolean values. |
+|  [summary?](./cdk-rest-api-with-spec.methodoptionswithspec.summary.md) |  | string | **_(BETA)_** _(Optional)_ Summary of the method. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.methodresponses.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.methodresponses.md
@@ -4,12 +4,12 @@
 
 ## MethodOptionsWithSpec.methodResponses property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Method responses augmented with properties necessary for the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 methodResponses?: MethodResponseWithSpec[];

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.requestparameterschemas.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.requestparameterschemas.md
@@ -4,12 +4,12 @@
 
 ## MethodOptionsWithSpec.requestParameterSchemas property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Request parameters which maps parameter objects for the OpenAPI definition instead of boolean values.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 requestParameterSchemas?: {

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.summary.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodoptionswithspec.summary.md
@@ -4,12 +4,12 @@
 
 ## MethodOptionsWithSpec.summary property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Summary of the method.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 summary?: string;

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodresponsewithspec.description.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodresponsewithspec.description.md
@@ -4,12 +4,12 @@
 
 ## MethodResponseWithSpec.description property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Description of the response.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 description?: string;

--- a/api-docs/markdown/cdk-rest-api-with-spec.methodresponsewithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.methodresponsewithspec.md
@@ -4,21 +4,21 @@
 
 ## MethodResponseWithSpec interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 [aws\_apigateway.MethodResponse](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodResponse.html) augmented with properties necessary for the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface MethodResponseWithSpec extends apigateway.MethodResponse 
 ```
-<b>Extends:</b> apigateway.MethodResponse
+**Extends:** apigateway.MethodResponse
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [description?](./cdk-rest-api-with-spec.methodresponsewithspec.description.md) |  | string | <b><i>(BETA)</i></b> <i>(Optional)</i> Description of the response. |
+|  [description?](./cdk-rest-api-with-spec.methodresponsewithspec.description.md) |  | string | **_(BETA)_** _(Optional)_ Description of the response. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.modeloptionswithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.modeloptionswithspec.md
@@ -4,17 +4,17 @@
 
 ## ModelOptionsWithSpec interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 [aws\_apigateway.ModelOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ModelOptions.html) augmented with the properties necessary to build the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface ModelOptionsWithSpec extends apigateway.ModelOptions 
 ```
-<b>Extends:</b> apigateway.ModelOptions
+**Extends:** apigateway.ModelOptions
 
 ## Remarks
 
@@ -24,5 +24,5 @@ Has an extended `schema`<!-- -->.
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [schema](./cdk-rest-api-with-spec.modeloptionswithspec.schema.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | <b><i>(BETA)</i></b> Extended schema definition. |
+|  [schema](./cdk-rest-api-with-spec.modeloptionswithspec.schema.md) |  | [JsonSchemaEx](./cdk-rest-api-with-spec.jsonschemaex.md) | **_(BETA)_** Extended schema definition. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.modeloptionswithspec.schema.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.modeloptionswithspec.schema.md
@@ -4,12 +4,12 @@
 
 ## ModelOptionsWithSpec.schema property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Extended schema definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 schema: JsonSchemaEx;

--- a/api-docs/markdown/cdk-rest-api-with-spec.parameterkey._constructor_.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.parameterkey._constructor_.md
@@ -4,12 +4,12 @@
 
 ## ParameterKey.(constructor)
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Constructs a new instance of the `ParameterKey` class
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 constructor(

--- a/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.direction.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.direction.md
@@ -4,12 +4,12 @@
 
 ## ParameterKey.direction property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Request or response.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly direction: 'request' | 'response';

--- a/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.explode.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.explode.md
@@ -4,12 +4,12 @@
 
 ## ParameterKey.explode property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Whether the parameter can have multiple values.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly explode: boolean;

--- a/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.location.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.location.md
@@ -4,12 +4,12 @@
 
 ## ParameterKey.location property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Location of the parameter.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly location: 'path' | 'query' | 'header';

--- a/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.md
@@ -4,12 +4,12 @@
 
 ## ParameterKey class
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Parsed request or response parameter key.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class ParameterKey 
@@ -19,20 +19,20 @@ export declare class ParameterKey
 
 |  Constructor | Modifiers | Description |
 |  --- | --- | --- |
-|  [(constructor)(direction, name, location, explode)](./cdk-rest-api-with-spec.parameterkey._constructor_.md) |  | <b><i>(BETA)</i></b> Constructs a new instance of the <code>ParameterKey</code> class |
+|  [(constructor)(direction, name, location, explode)](./cdk-rest-api-with-spec.parameterkey._constructor_.md) |  | **_(BETA)_** Constructs a new instance of the <code>ParameterKey</code> class |
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [direction](./cdk-rest-api-with-spec.parameterkey.direction.md) | <code>readonly</code> | 'request' \| 'response' | <b><i>(BETA)</i></b> Request or response. |
-|  [explode](./cdk-rest-api-with-spec.parameterkey.explode.md) | <code>readonly</code> | boolean | <b><i>(BETA)</i></b> Whether the parameter can have multiple values. |
-|  [location](./cdk-rest-api-with-spec.parameterkey.location.md) | <code>readonly</code> | 'path' \| 'query' \| 'header' | <b><i>(BETA)</i></b> Location of the parameter. |
-|  [name](./cdk-rest-api-with-spec.parameterkey.name.md) | <code>readonly</code> | string | <b><i>(BETA)</i></b> Name of the parameter. |
+|  [direction](./cdk-rest-api-with-spec.parameterkey.direction.md) | <code>readonly</code> | 'request' \| 'response' | **_(BETA)_** Request or response. |
+|  [explode](./cdk-rest-api-with-spec.parameterkey.explode.md) | <code>readonly</code> | boolean | **_(BETA)_** Whether the parameter can have multiple values. |
+|  [location](./cdk-rest-api-with-spec.parameterkey.location.md) | <code>readonly</code> | 'path' \| 'query' \| 'header' | **_(BETA)_** Location of the parameter. |
+|  [name](./cdk-rest-api-with-spec.parameterkey.name.md) | <code>readonly</code> | string | **_(BETA)_** Name of the parameter. |
 
 ## Methods
 
 |  Method | Modifiers | Description |
 |  --- | --- | --- |
-|  [parseParameterKey(key)](./cdk-rest-api-with-spec.parameterkey.parseparameterkey.md) | <code>static</code> | <b><i>(BETA)</i></b> Parses a given request or response parameter key. |
+|  [parseParameterKey(key)](./cdk-rest-api-with-spec.parameterkey.parseparameterkey.md) | <code>static</code> | **_(BETA)_** Parses a given request or response parameter key. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.name.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.name.md
@@ -4,12 +4,12 @@
 
 ## ParameterKey.name property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Name of the parameter.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly name: string;

--- a/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.parseparameterkey.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.parameterkey.parseparameterkey.md
@@ -4,12 +4,12 @@
 
 ## ParameterKey.parseParameterKey() method
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Parses a given request or response parameter key.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 static parseParameterKey(key: string): ParameterKey;
@@ -21,7 +21,7 @@ static parseParameterKey(key: string): ParameterKey;
 |  --- | --- | --- |
 |  key | string | Parameter key to be parsed. |
 
-<b>Returns:</b>
+**Returns:**
 
 [ParameterKey](./cdk-rest-api-with-spec.parameterkey.md)
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.resourceoptionswithspec.defaultmethodoptions.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.resourceoptionswithspec.defaultmethodoptions.md
@@ -4,12 +4,12 @@
 
 ## ResourceOptionsWithSpec.defaultMethodOptions property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Default method options with the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 defaultMethodOptions?: MethodOptionsWithSpec;

--- a/api-docs/markdown/cdk-rest-api-with-spec.resourceoptionswithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.resourceoptionswithspec.md
@@ -4,21 +4,21 @@
 
 ## ResourceOptionsWithSpec interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 [aws\_apigateway.ResourceOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.ResourceOptions.html) augmented with the properties necessary to build the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface ResourceOptionsWithSpec extends apigateway.ResourceOptions 
 ```
-<b>Extends:</b> apigateway.ResourceOptions
+**Extends:** apigateway.ResourceOptions
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [defaultMethodOptions?](./cdk-rest-api-with-spec.resourceoptionswithspec.defaultmethodoptions.md) |  | [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | <b><i>(BETA)</i></b> <i>(Optional)</i> Default method options with the OpenAPI definition. |
+|  [defaultMethodOptions?](./cdk-rest-api-with-spec.resourceoptionswithspec.defaultmethodoptions.md) |  | [MethodOptionsWithSpec](./cdk-rest-api-with-spec.methodoptionswithspec.md) | **_(BETA)_** _(Optional)_ Default method options with the OpenAPI definition. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec._constructor_.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec._constructor_.md
@@ -4,12 +4,12 @@
 
 ## RestApiWithSpec.(constructor)
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Initializes a REST API with the OpenAPI specification.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 constructor(scope: Construct, id: string, props: RestApiWithSpecProps);

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.addmodel.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.addmodel.md
@@ -4,12 +4,12 @@
 
 ## RestApiWithSpec.addModel() method
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Returns the `addModel` function augmented with the features to build the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 addModel(id: string, props: ModelOptionsWithSpec): apigateway.Model;
@@ -22,7 +22,7 @@ addModel(id: string, props: ModelOptionsWithSpec): apigateway.Model;
 |  id | string |  |
 |  props | [ModelOptionsWithSpec](./cdk-rest-api-with-spec.modeloptionswithspec.md) |  |
 
-<b>Returns:</b>
+**Returns:**
 
 apigateway.Model
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.md
@@ -4,19 +4,19 @@
 
 ## RestApiWithSpec class
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 CDK construct that provisions an API Gateway REST API endpoint and also synthesizes the OpenAPI definition for it.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class RestApiWithSpec extends apigateway.RestApi implements IRestApiWithSpec 
 ```
-<b>Extends:</b> apigateway.RestApi
+**Extends:** apigateway.RestApi
 
-<b>Implements:</b> [IRestApiWithSpec](./cdk-rest-api-with-spec.irestapiwithspec.md)
+**Implements:** [IRestApiWithSpec](./cdk-rest-api-with-spec.irestapiwithspec.md)
 
 ## Remarks
 
@@ -26,18 +26,18 @@ NOTE: Please turn on the validation of CDK stacks. If you skip the validation of
 
 |  Constructor | Modifiers | Description |
 |  --- | --- | --- |
-|  [(constructor)(scope, id, props)](./cdk-rest-api-with-spec.restapiwithspec._constructor_.md) |  | <b><i>(BETA)</i></b> Initializes a REST API with the OpenAPI specification. |
+|  [(constructor)(scope, id, props)](./cdk-rest-api-with-spec.restapiwithspec._constructor_.md) |  | **_(BETA)_** Initializes a REST API with the OpenAPI specification. |
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [props](./cdk-rest-api-with-spec.restapiwithspec.props.md) | <code>readonly</code> | [RestApiWithSpecProps](./cdk-rest-api-with-spec.restapiwithspecprops.md) | <b><i>(BETA)</i></b> |
-|  [root](./cdk-rest-api-with-spec.restapiwithspec.root.md) | <code>readonly</code> | [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | <b><i>(BETA)</i></b> Root resource with the OpenAPI definition. |
+|  [props](./cdk-rest-api-with-spec.restapiwithspec.props.md) | <code>readonly</code> | [RestApiWithSpecProps](./cdk-rest-api-with-spec.restapiwithspecprops.md) | **_(BETA)_** |
+|  [root](./cdk-rest-api-with-spec.restapiwithspec.root.md) | <code>readonly</code> | [IResourceWithSpec](./cdk-rest-api-with-spec.iresourcewithspec.md) | **_(BETA)_** Root resource with the OpenAPI definition. |
 
 ## Methods
 
 |  Method | Modifiers | Description |
 |  --- | --- | --- |
-|  [addModel(id, props)](./cdk-rest-api-with-spec.restapiwithspec.addmodel.md) |  | <b><i>(BETA)</i></b> Returns the <code>addModel</code> function augmented with the features to build the OpenAPI definition. |
+|  [addModel(id, props)](./cdk-rest-api-with-spec.restapiwithspec.addmodel.md) |  | **_(BETA)_** Returns the <code>addModel</code> function augmented with the features to build the OpenAPI definition. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.props.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.props.md
@@ -4,10 +4,10 @@
 
 ## RestApiWithSpec.props property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly props: RestApiWithSpecProps;

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.root.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.root.md
@@ -4,12 +4,12 @@
 
 ## RestApiWithSpec.root property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Root resource with the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly root: IResourceWithSpec;

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspecprops.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspecprops.md
@@ -4,22 +4,22 @@
 
 ## RestApiWithSpecProps interface
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Properties for [RestApiWithSpec](./cdk-rest-api-with-spec.restapiwithspec.md)<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface RestApiWithSpecProps extends apigateway.RestApiProps 
 ```
-<b>Extends:</b> apigateway.RestApiProps
+**Extends:** apigateway.RestApiProps
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [openApiInfo](./cdk-rest-api-with-spec.restapiwithspecprops.openapiinfo.md) |  | Partial&lt;InfoObject&gt; &amp; Pick&lt;InfoObject, 'version'&gt; | <b><i>(BETA)</i></b> Info object of the OpenAPI definition. |
-|  [openApiOutputPath](./cdk-rest-api-with-spec.restapiwithspecprops.openapioutputpath.md) |  | string | <b><i>(BETA)</i></b> Path to an output file where the OpenAPI definition is to be saved. |
+|  [openApiInfo](./cdk-rest-api-with-spec.restapiwithspecprops.openapiinfo.md) |  | Partial&lt;InfoObject&gt; &amp; Pick&lt;InfoObject, 'version'&gt; | **_(BETA)_** Info object of the OpenAPI definition. |
+|  [openApiOutputPath](./cdk-rest-api-with-spec.restapiwithspecprops.openapioutputpath.md) |  | string | **_(BETA)_** Path to an output file where the OpenAPI definition is to be saved. |
 

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspecprops.openapiinfo.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspecprops.openapiinfo.md
@@ -4,12 +4,12 @@
 
 ## RestApiWithSpecProps.openApiInfo property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Info object of the OpenAPI definition.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 openApiInfo: Partial<InfoObject> & Pick<InfoObject, 'version'>;

--- a/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspecprops.openapioutputpath.md
+++ b/api-docs/markdown/cdk-rest-api-with-spec.restapiwithspecprops.openapioutputpath.md
@@ -4,12 +4,12 @@
 
 ## RestApiWithSpecProps.openApiOutputPath property
 
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
 Path to an output file where the OpenAPI definition is to be saved.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 openApiOutputPath: string;

--- a/example/lib/example-stack.getimage.ts
+++ b/example/lib/example-stack.getimage.ts
@@ -1,0 +1,9 @@
+import type { APIGatewayEvent, Context, Handler } from 'aws-lambda';
+
+// Returns a PNG image containing a single transparent dot.
+export const handler: Handler = async (
+  event: APIGatewayEvent,
+  context: Context,
+): Promise<string> => {
+  return 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==';
+};

--- a/example/openapi.json
+++ b/example/openapi.json
@@ -163,6 +163,62 @@
           }
         ]
       }
+    },
+    "/pet/{petId}/photo": {
+      "parameters": [
+        {
+          "description": "ID of pet",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64",
+            "example": 123
+          },
+          "name": "petId",
+          "in": "path"
+        }
+      ]
+    },
+    "/pet/{petId}/photo/{photoId}": {
+      "parameters": [
+        {
+          "description": "ID of pet's photo",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64",
+            "example": 123
+          },
+          "name": "photoId",
+          "in": "path"
+        },
+        {
+          "description": "ID of pet",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64",
+            "example": 123
+          },
+          "name": "petId",
+          "in": "path"
+        }
+      ],
+      "get": {
+        "summary": "Find pet photo by ID",
+        "description": "Returns a single pet photo",
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet photo not found"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-rest-api-with-spec",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Describe Amazon API Gateway and OpenAPI at once with CDK",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
@@ -36,8 +36,8 @@
     "@microsoft/api-extractor": "^7.40.1",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/node": "^20.11.17",
-    "aws-cdk-lib": "^2.31.0",
-    "constructs": "^10.1.43",
+    "aws-cdk-lib": "^2.126.0",
+    "constructs": "^10.3.0",
     "rollup": "^4.9.6",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,10 @@ devDependencies:
     specifier: ^20.11.17
     version: 20.11.17
   aws-cdk-lib:
-    specifier: ^2.31.0
+    specifier: ^2.126.0
     version: 2.126.0(constructs@10.3.0)
   constructs:
-    specifier: ^10.1.43
+    specifier: ^10.3.0
     version: 10.3.0
   rollup:
     specifier: ^4.9.6


### PR DESCRIPTION
Issue:
- fixes #13

Changes:
- Merge `requestParameterSchemas` in `defaultMethodOptions` before calling the underlying [`Resource.addResource`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.Resource.html#addwbrresourcepathpart-options)
- Update the example to test if parameters are passed down
- Bump version to 0.2.3