### PR TITLE
Publish a developer package by GitHub Actions

### DIFF
--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -1,0 +1,14 @@
+name: Publish a developer package
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-package.yml

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -3,7 +3,7 @@ name: Publish a developer package
 on:
   push:
     branches:
-      - dev
+      - main
 
 permissions:
   packages: write

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -12,3 +12,9 @@ permissions:
 jobs:
   publish:
     uses: ./.github/workflows/publish-package.yml
+
+    with:
+      npm-registry-url: 'https://npm.pkg.github.com'
+
+    secrets:
+      npm-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -44,6 +44,7 @@ jobs:
           node-version: ${{ env.node-version }}
           cache: 'pnpm'
           registry-url: ${{ inputs.npm-registry-url }}
+          scope: '@codemonger-io'
 
       # appends the short commit hash to the version
       # 1. reads package information

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,6 +2,16 @@ name: Publish a package
 
 on:
   workflow_call:
+    inputs:
+      npm-registry-url:
+        description: 'URL of the npm registry to publish to; e.g., https://npm.pkg.github.com for GitHub Packages'
+        type: string
+        required: true
+
+    secrets:
+      npm-token:
+        description: 'Token that is allowed to publish to the npm registry; e.g., GITHUB_TOKEN for GitHub Packages'
+        required: true
 
 env:
   node-version: 22
@@ -33,6 +43,7 @@ jobs:
         with:
           node-version: ${{ env.node-version }}
           cache: 'pnpm'
+          registry-url: ${{ inputs.npm-registry-url }}
 
       # appends the short commit hash to the version
       # 1. reads package information
@@ -53,5 +64,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build
-        run: pnpm build
+      # the build script is executed by the prepare script
+      - name: Build and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+        run: pnpm publish

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,37 @@
+name: Publish a package
+
+on:
+  workflow_call:
+
+env:
+  node-version: 22
+  pnpm-version: 10
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build-dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm ${{ env.pnpm-version }}
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.pnpm-version }}
+
+      - name: Setup Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get short commit hash
+        id: commit-hash
+        run: echo "short-commit-hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Install pnpm ${{ env.pnpm-version }}
         uses: pnpm/action-setup@v4
         with:
@@ -29,6 +33,22 @@ jobs:
         with:
           node-version: ${{ env.node-version }}
           cache: 'pnpm'
+
+      # appends the short commit hash to the version
+      # 1. reads package information
+      # 2. appends the short commit hash to the version and writes it back
+      - name: Extract package information
+        id: package-info
+        # uses the exact commit to prevent harmful updates
+        uses: jaywcjlove/github-action-package@f6a7afaf74f96a166243f05560d5af4bd4eaa570
+        with:
+          path: package.json
+      - name: Append short commit hash to the version
+        # uses the exact commit to prevent harmful updates
+        uses: jaywcjlove/github-action-package@f6a7afaf74f96a166243f05560d5af4bd4eaa570
+        with:
+          path: package.json
+          version: ${{ steps.package-info.outputs.version }}-${{ steps.commit-hash.outputs.short-commit-hash }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Build and publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
-        run: pnpm publish
+        run: pnpm publish --no-git-checks

--- a/README.ja.md
+++ b/README.ja.md
@@ -30,6 +30,40 @@ npm install https://github.com/codemonger-io/cdk-rest-api-with-spec.git#v0.3.0
 
 CDK v2プロジェクトで使っている限り、これらを別途インストールする必要はないはずです。
 
+### GitHub Packagesからインストールする
+
+`main`ブランチにコミットがプッシュされるたびに、開発者用パッケージがGitHub Packagesの管理するnpmレジストリにパブリッシュされます。
+開発者用パッケージのバージョンは次のリリースバージョンとハイフン(`-`)と短いコミットハッシュををつなげたもので表現されます。例、`0.3.0-abc1234` (`abc1234`はパッケージをビルドするのに使ったコミット(*スナップショット*)のコミットハッシュ)。
+開発者用パッケージは[こちら](https://github.com/codemonger-io/cdk-rest-api-with-spec/pkgs/npm/cdk-rest-api-with-spec)にあります。
+
+#### GitHubパーソナルアクセストークンの設定
+
+開発者用パッケージをインストールするには、最低限`read:packages`スコープの**クラッシック**GitHubパーソナルアクセストークン(PAT)を設定する必要があります。
+以下、簡単にPATの設定方法を説明します。
+より詳しくは[GitHubのドキュメント](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)をご参照ください。
+
+PATが手に入ったら以下の内容の`.npmrc`ファイルをホームディレクトリに作成してください。
+
+```
+//npm.pkg.github.com/:_authToken=$YOUR_GITHUB_PAT
+```
+
+`$YOUR_GITHUB_PAT`はご自身のPATに置き換えてください。
+
+プロジェクトのルートディレクトリに以下の内容の`.npmrc`ファイルを作成してください。
+
+```
+@codemonger-io:registry=https://npm.pkg.github.com
+```
+
+これで以下のコマンドで開発者パッケージをインストールできます。
+
+```sh
+npm install @codemonger-io/cdk-rest-api-with-spec@0.3.0-abc1234
+```
+
+`abc1234`はインストールしたい*スナップショット*の短いコミットハッシュに置き換えてください。
+
 ## 始める
 
 [`aws_apigateway.RestApi`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApi.html)の代わりに[`RestApiWithSpec`](./api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.md)をインスタンス化してください。

--- a/README.md
+++ b/README.md
@@ -30,6 +30,40 @@ This library is supposed to be used in a CDK v2 project, so it does not include 
 
 As long as you are working on a CDK v2 project, you should not have to separately install them.
 
+### Installing from GitHub Packages
+
+Every time commits are pushed to the `main` branch, a developer package is published to the npm registry managed by GitHub Packages.
+The version of a developer package is represented by the next release version followed by a dash (`-`) plus the short commit hash; e.g., `0.3.0-abc1234` where `abc1234` is the short commit hash of the commit used to build the package (*snapshot*).
+You can find developer packages [here](https://github.com/codemonger-io/cdk-rest-api-with-spec/pkgs/npm/cdk-rest-api-with-spec).
+
+#### Configuring GitHub personal access token
+
+To install a developer package, you need to configure a **classic** GitHub personal access token (PAT) with at least the `read:packages` scope.
+Below briefly explains how to configure a PAT.
+Please refer to the [GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) for more details.
+
+Once you have a PAT, please create a `.npmrc` file in your home directory with the following content,
+
+```
+//npm.pkg.github.com/:_authToken=$YOUR_GITHUB_PAT
+```
+
+Please replace `$YOUR_GITHUB_PAT` with your PAT.
+
+In the root directory of your project, please create a `.npmrc` file with the following content,
+
+```
+@codemonger-io:registry=https://npm.pkg.github.com
+```
+
+Then you can install a developer package with the following command,
+
+```sh
+npm install @codemonger-io/cdk-rest-api-with-spec@0.3.0-abc1234
+```
+
+Please replace `abc1234` with the short commit hash of the *snapshot* you want to install.
+
 ## Getting started
 
 Please instantiate [`RestApiWithSpec`](./api-docs/markdown/cdk-rest-api-with-spec.restapiwithspec.md) instead of [`aws_apigateway.RestApi`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.RestApi.html).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "files": [
     "dist/index.js",
     "dist/index.d.ts",
-    "dist/index.js.map"
+    "dist/index.js.map",
+    "README.ja.md"
   ],
   "scripts": {
     "build": "rimraf dist && rollup -c && api-extractor run --local",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@codemonger-io/cdk-rest-api-with-spec",
   "version": "0.3.0",
   "description": "Describe Amazon API Gateway and OpenAPI at once with CDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codemonger-io/cdk-rest-api-with-spec.git"
+  },
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
### Proposed changes

Introduces a new GitHub Actions workflow that publishes a developer package to the GitHub npm registry when commits are pushed to the `main` branch.

The version of a developer package is represented as the next release version followed by a dash (`-`) plus the short commit hash of the commit used to build the package; e.g., `0.3.0-abc1234`.

### Related issues

- closes #18